### PR TITLE
Fixed post comment names

### DIFF
--- a/src/app/pages/post/post.component.html
+++ b/src/app/pages/post/post.component.html
@@ -98,7 +98,7 @@
                                     <div class="comment" *ngFor="let comment of comments; index as i;">
                                         <ul class="post-meta">
                                             <li class="post-meta-item">
-                                                <span class="author">{{post.author.alias}}</span>
+                                                <span class="author">{{comment.author.alias}}</span>
                                             </li>
                                             <li class="post-meta-item">
                                                 <span class="author">{{comment.karma}}</span> <i


### PR DESCRIPTION
Fixed the HTML on the Post page, so the comments have the right names attached, instead of all of them having the name of the post author.